### PR TITLE
feat: rework plugin class

### DIFF
--- a/acf-svg-icon-picker.php
+++ b/acf-svg-icon-picker.php
@@ -1,28 +1,37 @@
 <?php
-/*
-Plugin Name: Advanced Custom Fields: SVG Icon Picker
-Plugin URI: https://github.com/smithfield-studio/acf-svg-icon-picker
-Description: Allows you to pick an icon from a predefined list
-Version: 3.0.0
-Author: Houke de Kwant
-Author URI: https://github.com/houke/
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
-GitHub Plugin URI: https://github.com/smithfield-studio/acf-svg-icon-picker
-GitHub Branch: main
- */
+/**
+ * Plugin Name: Advanced Custom Fields: SVG Icon Picker
+ * Plugin URI: https://github.com/smithfield-studio/acf-svg-icon-picker
+ * Description: Allows you to pick an icon from a predefined list
+ * Version: 3.0.0
+ * Author: Houke de Kwant
+ * Author URI: https://github.com/houke/
+ * Text Domain: acf-svg-icon-picker
+ * License: GPLv2 or later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
+ * GitHub Plugin URI: https://github.com/smithfield-studio/acf-svg-icon-picker
+ * GitHub Branch: main
+ * Requires at least: 6.4
+ * Requires PHP: 7.4
+ *
+ * @package Advanced Custom Fields: SVG Icon Picker
+ **/
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'acf_plugin_svg_icon_picker' ) ) {
+if ( ! class_exists( 'Acf_Plugin_Svg_Icon_Picker' ) ) {
 	/**
 	 * Plugin class.
 	 */
-	class acf_plugin_svg_icon_picker {
+	class Acf_Plugin_Svg_Icon_Picker {
 
-
+		/**
+		 * Plugin settings.
+		 *
+		 * @var array
+		 */
 		public static $settings = array();
 
 		/**
@@ -40,18 +49,16 @@ if ( ! class_exists( 'acf_plugin_svg_icon_picker' ) ) {
 
 		/**
 		 * Include SVG Icon Picker field type.
-		 *
-		 * @param bool $version
 		 */
 		public function include_field_types() {
 			if ( ! function_exists( 'acf_register_field_type' ) ) {
 				return;
 			}
 
-			require_once __DIR__ . '/class-acf-svg-icon-picker-v5.php';
-			acf_register_field_type( 'acf_field_svg_icon_picker' );
+			require_once __DIR__ . '/class-acf-field-svg-icon-picker.php';
+			acf_register_field_type( 'ACF_Field_Svg_Icon_Picker' );
 		}
 	}
 }
 
-new acf_plugin_svg_icon_picker();
+new Acf_Plugin_Svg_Icon_Picker();

--- a/acf-svg-icon-picker.php
+++ b/acf-svg-icon-picker.php
@@ -17,22 +17,41 @@ if (!defined('ABSPATH')) {
 }
 
 if (!class_exists('acf_plugin_svg_icon_picker')) {
-    class acf_plugin_svg_icon_picker {
+    /** 
+     * Plugin class.
+     */
+    class acf_plugin_svg_icon_picker
+    {
 
-        public $settings = array();
+        public static $settings = array();
 
-        public function __construct() {
-            $this->settings = array(
+        /**
+         * Constructor.
+         */
+        public function __construct()
+        {
+            self::$settings = array(
                 'version' => '3.0.0',
-                'url' => plugin_dir_url(__FILE__),
-                'path' => plugin_dir_path(__FILE__),
+                'url'     => plugin_dir_url(__FILE__),
+                'path'    => plugin_dir_path(__FILE__),
             );
 
-            add_action('acf/include_field_types', array($this, 'include_field_types'));
+            add_action('init', array($this, 'include_field_types'));
         }
 
-        public function include_field_types($version = false) {
-            include_once 'fields/acf-svg-icon-picker-v5.php';
+        /**
+         * Include SVG Icon Picker field type.
+         *
+         * @param bool $version
+         */
+        public function include_field_types()
+        {
+            if (!function_exists('acf_register_field_type')) {
+                return;
+            }
+
+            require_once __DIR__ . '/class-acf-svg-icon-picker-v5.php';
+            acf_register_field_type('acf_field_svg_icon_picker');
         }
     }
 }

--- a/acf-svg-icon-picker.php
+++ b/acf-svg-icon-picker.php
@@ -12,48 +12,46 @@ GitHub Plugin URI: https://github.com/smithfield-studio/acf-svg-icon-picker
 GitHub Branch: main
  */
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-if (!class_exists('acf_plugin_svg_icon_picker')) {
-    /** 
-     * Plugin class.
-     */
-    class acf_plugin_svg_icon_picker
-    {
+if ( ! class_exists( 'acf_plugin_svg_icon_picker' ) ) {
+	/**
+	 * Plugin class.
+	 */
+	class acf_plugin_svg_icon_picker {
 
-        public static $settings = array();
 
-        /**
-         * Constructor.
-         */
-        public function __construct()
-        {
-            self::$settings = array(
-                'version' => '3.0.0',
-                'url'     => plugin_dir_url(__FILE__),
-                'path'    => plugin_dir_path(__FILE__),
-            );
+		public static $settings = array();
 
-            add_action('init', array($this, 'include_field_types'));
-        }
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			self::$settings = array(
+				'version' => '3.0.0',
+				'url'     => plugin_dir_url( __FILE__ ),
+				'path'    => plugin_dir_path( __FILE__ ),
+			);
 
-        /**
-         * Include SVG Icon Picker field type.
-         *
-         * @param bool $version
-         */
-        public function include_field_types()
-        {
-            if (!function_exists('acf_register_field_type')) {
-                return;
-            }
+			add_action( 'init', array( $this, 'include_field_types' ) );
+		}
 
-            require_once __DIR__ . '/class-acf-svg-icon-picker-v5.php';
-            acf_register_field_type('acf_field_svg_icon_picker');
-        }
-    }
+		/**
+		 * Include SVG Icon Picker field type.
+		 *
+		 * @param bool $version
+		 */
+		public function include_field_types() {
+			if ( ! function_exists( 'acf_register_field_type' ) ) {
+				return;
+			}
+
+			require_once __DIR__ . '/class-acf-svg-icon-picker-v5.php';
+			acf_register_field_type( 'acf_field_svg_icon_picker' );
+		}
+	}
 }
 
 new acf_plugin_svg_icon_picker();

--- a/acf-svg-icon-picker.php
+++ b/acf-svg-icon-picker.php
@@ -11,7 +11,6 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * GitHub Plugin URI: https://github.com/smithfield-studio/acf-svg-icon-picker
  * GitHub Branch: main
- * Requires at least: 6.4
  * Requires PHP: 7.4
  *
  * @package Advanced Custom Fields: SVG Icon Picker

--- a/class-acf-field-svg-icon-picker.php
+++ b/class-acf-field-svg-icon-picker.php
@@ -100,27 +100,25 @@ if ( ! class_exists( 'ACF_Field_Svg_Icon_Picker' ) ) {
 		public function render_field( $field ) {
 			$input_icon = '' !== $field['value'] ? $field['value'] : $field['initial_value'];
 			$svg        = $this->path . $input_icon . '.svg';
+			$svg_exists = file_exists( $svg );
+			$svg_url    = esc_url( $this->url . $input_icon . '.svg' );
+
 			?>
 			<div class="acf-svg-icon-picker">
 				<div class="acf-svg-icon-picker__img">
-					<?php
-					if ( file_exists( $svg ) ) {
-						$svg = $this->url . $input_icon . '.svg';
-						echo '<div class="acf-svg-icon-picker__svg">';
-						echo '<img src="' . esc_url( $svg ) . '" alt=""/>';
-						echo '</div>';
-					} else {
-						echo '<div class="acf-svg-icon-picker__svg">';
-						echo '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
-						echo '</div>';
-					}
-					?>
-					<input type="hidden" readonly name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo esc_attr( $input_icon ); ?>" />
+						<div class="acf-svg-icon-picker__svg">
+							<?php
+							echo $svg_exists
+								? '<img src="' . esc_url( $svg_url ) . '" alt=""/>'
+								: '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
+							?>
+						</div>
+						<input type="hidden" readonly name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo esc_attr( $input_icon ); ?>" />
 				</div>
-				<?php if ( false === $field['required'] ) { ?>
-					<span class="acf-svg-icon-picker__remove">
-						<?php esc_html_e( 'remove', 'acf-svg-icon-picker' ); ?>
-					</span>
+				<?php if ( ! $field['required'] ) { ?>
+						<span class="acf-svg-icon-picker__remove">
+							<?php esc_html_e( 'remove', 'acf-svg-icon-picker' ); ?>
+						</span>
 				<?php } ?>
 			</div>
 			<?php

--- a/class-acf-field-svg-icon-picker.php
+++ b/class-acf-field-svg-icon-picker.php
@@ -1,12 +1,20 @@
 <?php
+/**
+ * Field class for the SVG Icon Picker field.
+ *
+ * @package Advanced Custom Fields: SVG Icon Picker
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
-	class acf_field_svg_icon_picker extends \acf_field {
+if ( ! class_exists( 'ACF_Field_Svg_Icon_Picker' ) ) {
 
+	/**
+	 * Field class for the SVG Icon Picker field.
+	 */
+	class ACF_Field_Svg_Icon_Picker extends \acf_field {
 
 		/**
 		 * Controls field type visibility in REST requests.
@@ -68,7 +76,7 @@ if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
 
 			$files = array_diff( scandir( $this->path ), array( '.', '..' ) );
 			foreach ( $files as $file ) {
-				if ( pathinfo( $file, PATHINFO_EXTENSION ) == 'svg' ) {
+				if ( pathinfo( $file, PATHINFO_EXTENSION ) === 'svg' ) {
 					$name     = explode( '.', $file )[0];
 					$filename = pathinfo( $file, PATHINFO_FILENAME );
 					$icon     = array(
@@ -86,11 +94,11 @@ if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
 		/**
 		 * Method that renders the field in the admin.
 		 *
-		 * @param array $field
+		 * @param array $field The field array.
 		 * @return void
 		 */
 		public function render_field( $field ) {
-			$input_icon = $field['value'] != '' ? $field['value'] : $field['initial_value'];
+			$input_icon = '' !== $field['value'] ? $field['value'] : $field['initial_value'];
 			$svg        = $this->path . $input_icon . '.svg';
 			?>
 			<div class="acf-svg-icon-picker">
@@ -99,7 +107,7 @@ if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
 					if ( file_exists( $svg ) ) {
 						$svg = $this->url . $input_icon . '.svg';
 						echo '<div class="acf-svg-icon-picker__svg">';
-						echo '<img src="' . $svg . '" alt=""/>';
+						echo '<img src="' . esc_url( $svg ) . '" alt=""/>';
 						echo '</div>';
 					} else {
 						echo '<div class="acf-svg-icon-picker__svg">';
@@ -109,9 +117,9 @@ if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
 					?>
 					<input type="hidden" readonly name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo esc_attr( $input_icon ); ?>" />
 				</div>
-				<?php if ( $field['required'] == false ) { ?>
+				<?php if ( false === $field['required'] ) { ?>
 					<span class="acf-svg-icon-picker__remove">
-						<?php _e( 'remove', 'acf-svg-icon-picker' ); ?>
+						<?php esc_html_e( 'remove', 'acf-svg-icon-picker' ); ?>
 					</span>
 				<?php } ?>
 			</div>
@@ -127,7 +135,7 @@ if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
 			$url     = acf_plugin_svg_icon_picker::$settings['url'];
 			$version = acf_plugin_svg_icon_picker::$settings['version'];
 
-			wp_register_script( 'acf-input-svg-icon-picker', "{$url}assets/js/input.js", array( 'acf-input' ), $version );
+			wp_register_script( 'acf-input-svg-icon-picker', "{$url}assets/js/input.js", array( 'acf-input' ), $version, true );
 			wp_enqueue_script( 'acf-input-svg-icon-picker' );
 
 			wp_localize_script(
@@ -136,6 +144,7 @@ if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
 				array(
 					'path'         => $this->url,
 					'svgs'         => $this->svgs,
+					/* translators: %s: path_suffix */
 					'no_icons_msg' => sprintf( esc_html__( 'To add icons, add your svg files in the /%s folder in your theme.', 'acf-svg-icon-picker' ), $this->path_suffix ),
 				)
 			);

--- a/class-acf-svg-icon-picker-v5.php
+++ b/class-acf-svg-icon-picker-v5.php
@@ -1,146 +1,147 @@
 <?php
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-if (!class_exists('acf_field_svg_icon_picker')) {
-    class acf_field_svg_icon_picker extends \acf_field
-    {
-
-        /**
-         * Controls field type visibility in REST requests.
-         *
-         * @var bool
-         */
-        public $show_in_rest = true;
-
-        /**
-         * Stores the path suffix to the icons
-         *
-         * @var string
-         */
-        private string $path_suffix;
-
-        /**
-         * Stores the path to the icons
-         *
-         * @var string
-         */
-        private string $path;
-
-        /**
-         * Stores the url to the icons
-         *
-         * @var string
-         */
-        private string $url;
-
-        /**
-         * Stores the icons
-         *
-         * @var array
-         */
-        private array $svgs = array();
+if ( ! class_exists( 'acf_field_svg_icon_picker' ) ) {
+	class acf_field_svg_icon_picker extends \acf_field {
 
 
-        /**
-         * Constructor.
-         * 
-         * We set the field name, label, category, defaults and l10n.
-         */
-        public function __construct()
-        {
-            $this->name = 'icon-picker';
-            $this->label = __('SVG Icon Picker', 'acf-svg-icon-picker');
-            $this->category = 'content';
-            $this->defaults = array('initial_value' => '');
-            $this->l10n = array('error' => __('Error!', 'acf-svg-icon-picker'));
-            $this->path_suffix = apply_filters('acf_icon_path_suffix', 'assets/img/acf/');
-            $this->path = apply_filters('acf_icon_path', acf_plugin_svg_icon_picker::$settings['path']) . $this->path_suffix;
-            $this->url = apply_filters('acf_icon_url', acf_plugin_svg_icon_picker::$settings['url']) . $this->path_suffix;
+		/**
+		 * Controls field type visibility in REST requests.
+		 *
+		 * @var bool
+		 */
+		public $show_in_rest = true;
 
-            $priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
+		/**
+		 * Stores the path suffix to the icons
+		 *
+		 * @var string
+		 */
+		private string $path_suffix;
 
-            if (file_exists($priority_dir_lookup)) {
-                $this->path = $priority_dir_lookup;
-                $this->url = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
-            }
+		/**
+		 * Stores the path to the icons
+		 *
+		 * @var string
+		 */
+		private string $path;
 
-            $files = array_diff(scandir($this->path), array('.', '..'));
-            foreach ($files as $file) {
-                if (pathinfo($file, PATHINFO_EXTENSION) == 'svg') {
-                    $name = explode('.', $file)[0];
-                    $filename = pathinfo($file, PATHINFO_FILENAME);
-                    $icon = array(
-                        'name'    => $name,
-                        'filename' => $filename,
-                        'icon'    => $file,
-                    );
-                    array_push($this->svgs, $icon);
-                }
-            }
+		/**
+		 * Stores the url to the icons
+		 *
+		 * @var string
+		 */
+		private string $url;
 
-            parent::__construct();
-        }
+		/**
+		 * Stores the icons
+		 *
+		 * @var array
+		 */
+		private array $svgs = array();
 
-        /**
-         * Method that renders the field in the admin.
-         *
-         * @param array $field
-         * @return void
-         */
-        public function render_field($field)
-        {
-            $input_icon = $field['value'] != "" ? $field['value'] : $field['initial_value'];
-            $svg = $this->path . $input_icon . '.svg';
-?>
-            <div class="acf-svg-icon-picker">
-                <div class="acf-svg-icon-picker__img">
-                    <?php
-                    if (file_exists($svg)) {
-                        $svg = $this->url . $input_icon . '.svg';
-                        echo '<div class="acf-svg-icon-picker__svg">';
-                        echo '<img src="' . $svg . '" alt=""/>';
-                        echo '</div>';
-                    } else {
-                        echo '<div class="acf-svg-icon-picker__svg">';
-                        echo '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
-                        echo '</div>';
-                    }
-                    ?>
-                    <input type="hidden" readonly name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($input_icon) ?>" />
-                </div>
-                <?php if ($field['required'] == false) { ?>
-                    <span class="acf-svg-icon-picker__remove">
-                        <?php _e('remove', 'acf-svg-icon-picker'); ?>
-                    </span>
-                <?php } ?>
-            </div>
-<?php
-        }
 
-        /**
-         * Enqueue assets for the field.
-         *
-         * @return void
-         */
-        public function input_admin_enqueue_scripts()
-        {
-            $url = acf_plugin_svg_icon_picker::$settings['url'];
-            $version = acf_plugin_svg_icon_picker::$settings['version'];
+		/**
+		 * Constructor.
+		 *
+		 * We set the field name, label, category, defaults and l10n.
+		 */
+		public function __construct() {
+			$this->name        = 'icon-picker';
+			$this->label       = __( 'SVG Icon Picker', 'acf-svg-icon-picker' );
+			$this->category    = 'content';
+			$this->defaults    = array( 'initial_value' => '' );
+			$this->l10n        = array( 'error' => __( 'Error!', 'acf-svg-icon-picker' ) );
+			$this->path_suffix = apply_filters( 'acf_icon_path_suffix', 'assets/img/acf/' );
+			$this->path        = apply_filters( 'acf_icon_path', acf_plugin_svg_icon_picker::$settings['path'] ) . $this->path_suffix;
+			$this->url         = apply_filters( 'acf_icon_url', acf_plugin_svg_icon_picker::$settings['url'] ) . $this->path_suffix;
 
-            wp_register_script('acf-input-svg-icon-picker', "{$url}assets/js/input.js", array('acf-input'), $version);
-            wp_enqueue_script('acf-input-svg-icon-picker');
+			$priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
 
-            wp_localize_script('acf-input-svg-icon-picker', 'acfSvgIconPicker', array(
-                'path' => $this->url,
-                'svgs' => $this->svgs,
-                'no_icons_msg' => sprintf(esc_html__('To add icons, add your svg files in the /%s folder in your theme.', 'acf-svg-icon-picker'), $this->path_suffix),
-            ));
+			if ( file_exists( $priority_dir_lookup ) ) {
+				$this->path = $priority_dir_lookup;
+				$this->url  = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
+			}
 
-            wp_register_style('acf-input-svg-icon-picker', "{$url}assets/css/input.css", array('acf-input'), $version);
-            wp_enqueue_style('acf-input-svg-icon-picker');
-        }
-    }
+			$files = array_diff( scandir( $this->path ), array( '.', '..' ) );
+			foreach ( $files as $file ) {
+				if ( pathinfo( $file, PATHINFO_EXTENSION ) == 'svg' ) {
+					$name     = explode( '.', $file )[0];
+					$filename = pathinfo( $file, PATHINFO_FILENAME );
+					$icon     = array(
+						'name'     => $name,
+						'filename' => $filename,
+						'icon'     => $file,
+					);
+					array_push( $this->svgs, $icon );
+				}
+			}
+
+			parent::__construct();
+		}
+
+		/**
+		 * Method that renders the field in the admin.
+		 *
+		 * @param array $field
+		 * @return void
+		 */
+		public function render_field( $field ) {
+			$input_icon = $field['value'] != '' ? $field['value'] : $field['initial_value'];
+			$svg        = $this->path . $input_icon . '.svg';
+			?>
+			<div class="acf-svg-icon-picker">
+				<div class="acf-svg-icon-picker__img">
+					<?php
+					if ( file_exists( $svg ) ) {
+						$svg = $this->url . $input_icon . '.svg';
+						echo '<div class="acf-svg-icon-picker__svg">';
+						echo '<img src="' . $svg . '" alt=""/>';
+						echo '</div>';
+					} else {
+						echo '<div class="acf-svg-icon-picker__svg">';
+						echo '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
+						echo '</div>';
+					}
+					?>
+					<input type="hidden" readonly name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo esc_attr( $input_icon ); ?>" />
+				</div>
+				<?php if ( $field['required'] == false ) { ?>
+					<span class="acf-svg-icon-picker__remove">
+						<?php _e( 'remove', 'acf-svg-icon-picker' ); ?>
+					</span>
+				<?php } ?>
+			</div>
+			<?php
+		}
+
+		/**
+		 * Enqueue assets for the field.
+		 *
+		 * @return void
+		 */
+		public function input_admin_enqueue_scripts() {
+			$url     = acf_plugin_svg_icon_picker::$settings['url'];
+			$version = acf_plugin_svg_icon_picker::$settings['version'];
+
+			wp_register_script( 'acf-input-svg-icon-picker', "{$url}assets/js/input.js", array( 'acf-input' ), $version );
+			wp_enqueue_script( 'acf-input-svg-icon-picker' );
+
+			wp_localize_script(
+				'acf-input-svg-icon-picker',
+				'acfSvgIconPicker',
+				array(
+					'path'         => $this->url,
+					'svgs'         => $this->svgs,
+					'no_icons_msg' => sprintf( esc_html__( 'To add icons, add your svg files in the /%s folder in your theme.', 'acf-svg-icon-picker' ), $this->path_suffix ),
+				)
+			);
+
+			wp_register_style( 'acf-input-svg-icon-picker', "{$url}assets/css/input.css", array( 'acf-input' ), $version );
+			wp_enqueue_style( 'acf-input-svg-icon-picker' );
+		}
+	}
 }

--- a/class-acf-svg-icon-picker-v5.php
+++ b/class-acf-svg-icon-picker-v5.php
@@ -5,13 +5,15 @@ if (!defined('ABSPATH')) {
 }
 
 if (!class_exists('acf_field_svg_icon_picker')) {
-    class acf_field_svg_icon_picker extends acf_field {
+    class acf_field_svg_icon_picker extends \acf_field
+    {
+
         /**
-         * Stores the settings for the field
+         * Controls field type visibility in REST requests.
          *
-         * @var array
+         * @var bool
          */
-        private array $settings = array();
+        public $show_in_rest = true;
 
         /**
          * Stores the path suffix to the icons
@@ -41,16 +43,22 @@ if (!class_exists('acf_field_svg_icon_picker')) {
          */
         private array $svgs = array();
 
-        public function __construct($settings) {
+
+        /**
+         * Constructor.
+         * 
+         * We set the field name, label, category, defaults and l10n.
+         */
+        public function __construct()
+        {
             $this->name = 'icon-picker';
             $this->label = __('SVG Icon Picker', 'acf-svg-icon-picker');
             $this->category = 'content';
             $this->defaults = array('initial_value' => '');
             $this->l10n = array('error' => __('Error!', 'acf-svg-icon-picker'));
-            $this->settings = $settings;
             $this->path_suffix = apply_filters('acf_icon_path_suffix', 'assets/img/acf/');
-            $this->path = apply_filters('acf_icon_path', $this->settings['path']) . $this->path_suffix;
-            $this->url = apply_filters('acf_icon_url', $this->settings['url']) . $this->path_suffix;
+            $this->path = apply_filters('acf_icon_path', acf_plugin_svg_icon_picker::$settings['path']) . $this->path_suffix;
+            $this->url = apply_filters('acf_icon_url', acf_plugin_svg_icon_picker::$settings['url']) . $this->path_suffix;
 
             $priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
 
@@ -76,38 +84,51 @@ if (!class_exists('acf_field_svg_icon_picker')) {
             parent::__construct();
         }
 
-        public function render_field($field) {
+        /**
+         * Method that renders the field in the admin.
+         *
+         * @param array $field
+         * @return void
+         */
+        public function render_field($field)
+        {
             $input_icon = $field['value'] != "" ? $field['value'] : $field['initial_value'];
             $svg = $this->path . $input_icon . '.svg';
-        ?>
+?>
             <div class="acf-svg-icon-picker">
-            <div class="acf-svg-icon-picker__img">
-            <?php
-            if (file_exists($svg)) {
-                $svg = $this->url . $input_icon . '.svg';
-                echo '<div class="acf-svg-icon-picker__svg">';
-                echo '<img src="' . $svg . '" alt=""/>';
-                echo '</div>';
-            } else {
-                echo '<div class="acf-svg-icon-picker__svg">';
-                echo '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
-                echo '</div>';
-            }
-            ?>
-                <input type="hidden" readonly name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($input_icon) ?>"/>
+                <div class="acf-svg-icon-picker__img">
+                    <?php
+                    if (file_exists($svg)) {
+                        $svg = $this->url . $input_icon . '.svg';
+                        echo '<div class="acf-svg-icon-picker__svg">';
+                        echo '<img src="' . $svg . '" alt=""/>';
+                        echo '</div>';
+                    } else {
+                        echo '<div class="acf-svg-icon-picker__svg">';
+                        echo '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
+                        echo '</div>';
+                    }
+                    ?>
+                    <input type="hidden" readonly name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($input_icon) ?>" />
+                </div>
+                <?php if ($field['required'] == false) { ?>
+                    <span class="acf-svg-icon-picker__remove">
+                        <?php _e('remove', 'acf-svg-icon-picker'); ?>
+                    </span>
+                <?php } ?>
             </div>
-            <?php if ($field['required'] == false) {?>
-                <span class="acf-svg-icon-picker__remove">
-                Remove
-                </span>
-            <?php }?>
-            </div>
-        <?php
-    }
+<?php
+        }
 
-        public function input_admin_enqueue_scripts() {
-            $url = $this->settings['url'];
-            $version = $this->settings['version'];
+        /**
+         * Enqueue assets for the field.
+         *
+         * @return void
+         */
+        public function input_admin_enqueue_scripts()
+        {
+            $url = acf_plugin_svg_icon_picker::$settings['url'];
+            $version = acf_plugin_svg_icon_picker::$settings['version'];
 
             wp_register_script('acf-input-svg-icon-picker', "{$url}assets/js/input.js", array('acf-input'), $version);
             wp_enqueue_script('acf-input-svg-icon-picker');
@@ -123,4 +144,3 @@ if (!class_exists('acf_field_svg_icon_picker')) {
         }
     }
 }
-new acf_field_svg_icon_picker($this->settings);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,7 @@
 	<arg name="basepath" value="." />
 
 	<!-- Set a minimum PHP version for PHPCompatibility -->
-	<config name="testVersion" value="8.0-" />
+	<config name="testVersion" value="7.4-" />
 
    <!-- Use 10up's phpcs ruleset -->
 	<rule ref="10up-Default">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,30 +3,24 @@
 	<!-- Files or directories to check -->
 	<file>.</file>
 
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
    <exclude-pattern>*/wordpress/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-   <exclude-pattern>*/resources/*</exclude-pattern>
-	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
 
 	<!-- Path to strip from the front of file paths inside reports (displays shorter paths) -->
 	<arg name="basepath" value="." />
 
 	<!-- Set a minimum PHP version for PHPCompatibility -->
-	<config name="testVersion" value="8.1-" />
+	<config name="testVersion" value="8.0-" />
 
-	<rule ref="10up-Default" />
-	<rule ref="WordPress-Core" />
-	<rule ref="WordPress-Docs" />
-	<rule ref="WordPress-Extra" />
-	<!-- Add VIP-specific rules -->
-	<config name="minimum_supported_wp_version" value="6.1"/>
+   <!-- Use 10up's phpcs ruleset -->
+	<rule ref="10up-Default">
+	</rule>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="acf-svg-icon-picker"/>
 		</properties>
 	</rule>
-
+	
 </ruleset>


### PR DESCRIPTION
Based on https://github.com/AdvancedCustomFields/acf-example-field-type I made a small initial rework of the plugin:

- In the plugin class, made settings a static so we can reference it in the field class.
- used the new `acf_register_field_type()` as per example
- documented class and methods
- The `remove` buttons is also translated

I already pushed some changes directly to main if you don't mind. These include:

- support files for GitHub
- PHPCS config and runner in composer file
- .gitattributes file to reduce the files in export once we publish to packagist.org