### PR TITLE
6 namespace plugin to prevent class exist lookups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @mike-sheppard @Levdbas

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ add_filter('acf_icon_url',
 ## Using with [ACF Builder](https://github.com/StoutLogic/acf-builder) / [ACF Composer](https://github.com/Log1x/acf-composer)
 
 ```php
-$fields->addField('my_icon', 'svg-icon-picker', [
+$fields->addField('my_icon', 'icon-picker', [
     'label' => 'My Icon',
 ])
 ```

--- a/acf-svg-icon-picker.php
+++ b/acf-svg-icon-picker.php
@@ -16,48 +16,29 @@
  * @package Advanced Custom Fields: SVG Icon Picker
  **/
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+namespace SmithfieldStudio\AcfSvgIconPicker;
 
-if ( ! class_exists( 'Acf_Plugin_Svg_Icon_Picker' ) ) {
-	/**
-	 * Plugin class.
-	 */
-	class Acf_Plugin_Svg_Icon_Picker {
+defined( 'ABSPATH' ) || exit;
 
-		/**
-		 * Plugin settings.
-		 *
-		 * @var array
-		 */
-		public static $settings = array();
+/**
+ * Change this version number and the version in the 
+ * docblock above when releasing a new version of this plugin.
+ */
+define( 'ACF_SVG_ICON_PICKER_VERSION', '3.0.0' );
 
-		/**
-		 * Constructor.
-		 */
-		public function __construct() {
-			self::$settings = array(
-				'version' => '3.0.0',
-				'url'     => plugin_dir_url( __FILE__ ),
-				'path'    => plugin_dir_path( __FILE__ ),
-			);
+define( 'ACF_SVG_ICON_PICKER_URL', plugin_dir_url( __FILE__ ) );
+define( 'ACF_SVG_ICON_PICKER_PATH', plugin_dir_path( __FILE__ ) );
 
-			add_action( 'init', array( $this, 'include_field_types' ) );
-		}
-
-		/**
-		 * Include SVG Icon Picker field type.
-		 */
-		public function include_field_types() {
-			if ( ! function_exists( 'acf_register_field_type' ) ) {
-				return;
-			}
-
-			require_once __DIR__ . '/class-acf-field-svg-icon-picker.php';
-			acf_register_field_type( 'ACF_Field_Svg_Icon_Picker' );
-		}
+/**
+ * Include SVG Icon Picker field type.
+ */
+function include_field_types() {
+	if ( ! function_exists( 'acf_register_field_type' ) ) {
+		return;
 	}
+
+	require_once __DIR__ . '/class-acf-field-svg-icon-picker.php';
+	acf_register_field_type( 'SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker' );
 }
 
-new Acf_Plugin_Svg_Icon_Picker();
+add_action( 'init', __NAMESPACE__ .'\\include_field_types' );

--- a/acf-svg-icon-picker.php
+++ b/acf-svg-icon-picker.php
@@ -21,7 +21,7 @@ namespace SmithfieldStudio\AcfSvgIconPicker;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Change this version number and the version in the 
+ * Change this version number and the version in the
  * docblock above when releasing a new version of this plugin.
  */
 define( 'ACF_SVG_ICON_PICKER_VERSION', '3.0.0' );
@@ -41,4 +41,4 @@ function include_field_types() {
 	acf_register_field_type( 'SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker' );
 }
 
-add_action( 'init', __NAMESPACE__ .'\\include_field_types' );
+add_action( 'init', __NAMESPACE__ . '\\include_field_types' );

--- a/class-acf-field-svg-icon-picker.php
+++ b/class-acf-field-svg-icon-picker.php
@@ -10,109 +10,107 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! class_exists( 'ACF_Field_Svg_Icon_Picker' ) ) {
-
 	/**
 	 * Field class for the SVG Icon Picker field.
 	 */
-	class ACF_Field_Svg_Icon_Picker extends \acf_field {
+class ACF_Field_Svg_Icon_Picker extends \acf_field {
 
-		/**
-		 * Controls field type visibility in REST requests.
-		 *
-		 * @var bool
-		 */
-		public $show_in_rest = true;
+	/**
+	 * Controls field type visibility in REST requests.
+	 *
+	 * @var bool
+	 */
+	public $show_in_rest = true;
 
-		/**
-		 * Stores the path suffix to the icons
-		 *
-		 * @var string
-		 */
-		private string $path_suffix;
+	/**
+	 * Stores the path suffix to the icons
+	 *
+	 * @var string
+	 */
+	private string $path_suffix;
 
-		/**
-		 * Stores the path to the icons
-		 *
-		 * @var string
-		 */
-		private string $path;
+	/**
+	 * Stores the path to the icons
+	 *
+	 * @var string
+	 */
+	private string $path;
 
-		/**
-		 * Stores the url to the icons
-		 *
-		 * @var string
-		 */
-		private string $url;
+	/**
+	 * Stores the url to the icons
+	 *
+	 * @var string
+	 */
+	private string $url;
 
-		/**
-		 * Stores the icons
-		 *
-		 * @var array
-		 */
-		private array $svgs = array();
+	/**
+	 * Stores the icons
+	 *
+	 * @var array
+	 */
+	private array $svgs = array();
 
 
-		/**
-		 * Constructor.
-		 *
-		 * We set the field name, label, category, defaults and l10n.
-		 */
-		public function __construct() {
-			$this->name        = 'icon-picker';
-			$this->label       = __( 'SVG Icon Picker', 'acf-svg-icon-picker' );
-			$this->category    = 'content';
-			$this->defaults    = array( 'initial_value' => '' );
-			$this->l10n        = array( 'error' => __( 'Error!', 'acf-svg-icon-picker' ) );
-			$this->path_suffix = apply_filters( 'acf_icon_path_suffix', 'assets/img/acf/' );
-			$this->path        = apply_filters( 'acf_icon_path', ACF_SVG_ICON_PICKER_PATH ) . $this->path_suffix;
-			$this->url         = apply_filters( 'acf_icon_url', ACF_SVG_ICON_PICKER_URL ) . $this->path_suffix;
+	/**
+	 * Constructor.
+	 *
+	 * We set the field name, label, category, defaults and l10n.
+	 */
+	public function __construct() {
+		$this->name        = 'icon-picker';
+		$this->label       = __( 'SVG Icon Picker', 'acf-svg-icon-picker' );
+		$this->category    = 'content';
+		$this->defaults    = array( 'initial_value' => '' );
+		$this->l10n        = array( 'error' => __( 'Error!', 'acf-svg-icon-picker' ) );
+		$this->path_suffix = apply_filters( 'acf_icon_path_suffix', 'assets/img/acf/' );
+		$this->path        = apply_filters( 'acf_icon_path', ACF_SVG_ICON_PICKER_PATH ) . $this->path_suffix;
+		$this->url         = apply_filters( 'acf_icon_url', ACF_SVG_ICON_PICKER_URL ) . $this->path_suffix;
 
-			$priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
+		$priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
 
-			if ( file_exists( $priority_dir_lookup ) ) {
-				$this->path = $priority_dir_lookup;
-				$this->url  = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
-			}
-
-			$files = array_diff( scandir( $this->path ), array( '.', '..' ) );
-			foreach ( $files as $file ) {
-				if ( pathinfo( $file, PATHINFO_EXTENSION ) === 'svg' ) {
-					$name     = explode( '.', $file )[0];
-					$filename = pathinfo( $file, PATHINFO_FILENAME );
-					$icon     = array(
-						'name'     => $name,
-						'filename' => $filename,
-						'icon'     => $file,
-					);
-					array_push( $this->svgs, $icon );
-				}
-			}
-
-			parent::__construct();
+		if ( file_exists( $priority_dir_lookup ) ) {
+			$this->path = $priority_dir_lookup;
+			$this->url  = get_stylesheet_directory_uri() . '/' . $this->path_suffix;
 		}
 
-		/**
-		 * Method that renders the field in the admin.
-		 *
-		 * @param array $field The field array.
-		 * @return void
-		 */
-		public function render_field( $field ) {
-			$input_icon = '' !== $field['value'] ? $field['value'] : $field['initial_value'];
-			$svg        = $this->path . $input_icon . '.svg';
-			$svg_exists = file_exists( $svg );
-			$svg_url    = esc_url( $this->url . $input_icon . '.svg' );
+		$files = array_diff( scandir( $this->path ), array( '.', '..' ) );
+		foreach ( $files as $file ) {
+			if ( pathinfo( $file, PATHINFO_EXTENSION ) === 'svg' ) {
+				$name     = explode( '.', $file )[0];
+				$filename = pathinfo( $file, PATHINFO_FILENAME );
+				$icon     = array(
+					'name'     => $name,
+					'filename' => $filename,
+					'icon'     => $file,
+				);
+				array_push( $this->svgs, $icon );
+			}
+		}
 
-			?>
+		parent::__construct();
+	}
+
+	/**
+	 * Method that renders the field in the admin.
+	 *
+	 * @param array $field The field array.
+	 * @return void
+	 */
+	public function render_field( $field ) {
+		$input_icon = '' !== $field['value'] ? $field['value'] : $field['initial_value'];
+		$svg        = $this->path . $input_icon . '.svg';
+		$svg_exists = file_exists( $svg );
+		$svg_url    = esc_url( $this->url . $input_icon . '.svg' );
+
+		?>
 			<div class="acf-svg-icon-picker">
 				<div class="acf-svg-icon-picker__img">
 						<div class="acf-svg-icon-picker__svg">
-							<?php
-							echo $svg_exists
-								? '<img src="' . esc_url( $svg_url ) . '" alt=""/>'
-								: '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
-							?>
+						<?php
+						echo $svg_exists
+							? '<img src="' . esc_url( $svg_url ) . '" alt=""/>'
+							: '<span class="acf-svg-icon-picker__svg--span">&plus;</span>';
+						?>
 						</div>
 						<input type="hidden" readonly name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo esc_attr( $input_icon ); ?>" />
 				</div>
@@ -123,32 +121,31 @@ if ( ! class_exists( 'ACF_Field_Svg_Icon_Picker' ) ) {
 				<?php } ?>
 			</div>
 			<?php
-		}
+	}
 
-		/**
-		 * Enqueue assets for the field.
-		 *
-		 * @return void
-		 */
-		public function input_admin_enqueue_scripts() {
-			$url     = ACF_SVG_ICON_PICKER_URL;
+	/**
+	 * Enqueue assets for the field.
+	 *
+	 * @return void
+	 */
+	public function input_admin_enqueue_scripts() {
+		$url = ACF_SVG_ICON_PICKER_URL;
 
-			wp_register_script( 'acf-input-svg-icon-picker', "{$url}assets/js/input.js", array( 'acf-input' ), ACF_SVG_ICON_PICKER_VERSION, true );
-			wp_enqueue_script( 'acf-input-svg-icon-picker' );
+		wp_register_script( 'acf-input-svg-icon-picker', "{$url}assets/js/input.js", array( 'acf-input' ), ACF_SVG_ICON_PICKER_VERSION, true );
+		wp_enqueue_script( 'acf-input-svg-icon-picker' );
 
-			wp_localize_script(
-				'acf-input-svg-icon-picker',
-				'acfSvgIconPicker',
-				array(
-					'path'         => $this->url,
-					'svgs'         => $this->svgs,
-					/* translators: %s: path_suffix */
-					'no_icons_msg' => sprintf( esc_html__( 'To add icons, add your svg files in the /%s folder in your theme.', 'acf-svg-icon-picker' ), $this->path_suffix ),
-				)
-			);
+		wp_localize_script(
+			'acf-input-svg-icon-picker',
+			'acfSvgIconPicker',
+			array(
+				'path'         => $this->url,
+				'svgs'         => $this->svgs,
+				/* translators: %s: path_suffix */
+				'no_icons_msg' => sprintf( esc_html__( 'To add icons, add your svg files in the /%s folder in your theme.', 'acf-svg-icon-picker' ), $this->path_suffix ),
+			)
+		);
 
-			wp_register_style( 'acf-input-svg-icon-picker', "{$url}assets/css/input.css", array( 'acf-input' ), ACF_SVG_ICON_PICKER_VERSION );
-			wp_enqueue_style( 'acf-input-svg-icon-picker' );
-		}
+		wp_register_style( 'acf-input-svg-icon-picker', "{$url}assets/css/input.css", array( 'acf-input' ), ACF_SVG_ICON_PICKER_VERSION );
+		wp_enqueue_style( 'acf-input-svg-icon-picker' );
 	}
 }

--- a/class-acf-field-svg-icon-picker.php
+++ b/class-acf-field-svg-icon-picker.php
@@ -4,6 +4,7 @@
  *
  * @package Advanced Custom Fields: SVG Icon Picker
  */
+namespace SmithfieldStudio\AcfSvgIconPicker;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -64,8 +65,8 @@ if ( ! class_exists( 'ACF_Field_Svg_Icon_Picker' ) ) {
 			$this->defaults    = array( 'initial_value' => '' );
 			$this->l10n        = array( 'error' => __( 'Error!', 'acf-svg-icon-picker' ) );
 			$this->path_suffix = apply_filters( 'acf_icon_path_suffix', 'assets/img/acf/' );
-			$this->path        = apply_filters( 'acf_icon_path', acf_plugin_svg_icon_picker::$settings['path'] ) . $this->path_suffix;
-			$this->url         = apply_filters( 'acf_icon_url', acf_plugin_svg_icon_picker::$settings['url'] ) . $this->path_suffix;
+			$this->path        = apply_filters( 'acf_icon_path', ACF_SVG_ICON_PICKER_PATH ) . $this->path_suffix;
+			$this->url         = apply_filters( 'acf_icon_url', ACF_SVG_ICON_PICKER_URL ) . $this->path_suffix;
 
 			$priority_dir_lookup = get_stylesheet_directory() . '/' . $this->path_suffix;
 
@@ -130,10 +131,9 @@ if ( ! class_exists( 'ACF_Field_Svg_Icon_Picker' ) ) {
 		 * @return void
 		 */
 		public function input_admin_enqueue_scripts() {
-			$url     = acf_plugin_svg_icon_picker::$settings['url'];
-			$version = acf_plugin_svg_icon_picker::$settings['version'];
+			$url     = ACF_SVG_ICON_PICKER_URL;
 
-			wp_register_script( 'acf-input-svg-icon-picker', "{$url}assets/js/input.js", array( 'acf-input' ), $version, true );
+			wp_register_script( 'acf-input-svg-icon-picker', "{$url}assets/js/input.js", array( 'acf-input' ), ACF_SVG_ICON_PICKER_VERSION, true );
 			wp_enqueue_script( 'acf-input-svg-icon-picker' );
 
 			wp_localize_script(
@@ -147,7 +147,7 @@ if ( ! class_exists( 'ACF_Field_Svg_Icon_Picker' ) ) {
 				)
 			);
 
-			wp_register_style( 'acf-input-svg-icon-picker', "{$url}assets/css/input.css", array( 'acf-input' ), $version );
+			wp_register_style( 'acf-input-svg-icon-picker', "{$url}assets/css/input.css", array( 'acf-input' ), ACF_SVG_ICON_PICKER_VERSION );
 			wp_enqueue_style( 'acf-input-svg-icon-picker' );
 		}
 	}


### PR DESCRIPTION
Related:

- #6

## Issue
Plugin is not namespaced and has a plugin class which is not really needed. Constants are better in such a small plugin.


## Solution
Lets fix that!


## Impact
Easier to maintain the plugin and no more collision with other classes in the future.


## Usage Changes
No.

## Considerations
Maybe you have another namespace in mind @mike-sheppard ?

## Testing
Not yet.