### PR TITLE
Fix filter on filenames with diacritical marks

### DIFF
--- a/assets/js/input.js
+++ b/assets/js/input.js
@@ -151,9 +151,10 @@
       const iconsFilter = document.querySelector('#filterIcons');
 
       function filterIcons(wordToMatch) {
+        const normalizedWord = wordToMatch.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
         return acfSvgIconPicker.svgs.filter(icon => {
-          var name = icon.name.replace(/[-_]/g, ' ');
-          const regex = new RegExp(wordToMatch, 'gi');
+          var name = icon.name.replace(/[-_]/g, ' ').normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+          const regex = new RegExp(normalizedWord, 'gi');
           return name.match(regex);
         });
       }


### PR DESCRIPTION
Related:

- #19 

## Issue
Can't filter on file names with å and Å. In looking for a fix, I found it it's called characters with diacritical marks


## Solution
I got some help from ChatGPT.
This solution normalizes words by splitting the diacritical marks in the filter function, so now `forhånd` and `forhand` result in the same files. Before, when trying to filter on `forhåndsvisning`, I had to stop after `forha`, because the filter didn't match anymore (in the filename, the å was split up in a and º, but I couldn't type that in the filter of course).
After it has normalized the characters, it then removes the diacritical marks. They're still displayed in the overview, but in the filter function, they are ignored.

![image](https://github.com/user-attachments/assets/27d2a8a0-e01c-4b25-b9a2-ed3821853f23)

![image](https://github.com/user-attachments/assets/6652c3d9-0127-49f1-a548-5f7dbed60def)


## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
I can't imagine this will have any impact on either the codebase, performance or backwards compatibility. It'll only impact users (positively!) who work with alphabets with diacritical characters


## Usage Changes
Filter now supports filtering on words with diacritical characters


## Considerations
I got help from ChatGPT to fix this. I think it's a good idea if a "real" developer takes a good look at the solution before merging it into the main branch.


## Testing
No unit tests included, but I also doubt there has to be a unit test for such a small addition?
