### PR TITLE
Small enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ We recommend storing your SVG icons in a folder within your theme. This plugin d
 
 When using this plugin in conjunction with a parent/child theme, you can store your icons in the parent theme and use the child theme to override the path to the icons. This way, you can provide a set of icons in the parent theme and still allow the child theme to override them.
 
+You can configure this field to output the icon name or the icon SVG markup. You can set this in the field settings by changing the `return_format`.
+
 ### Helper functions
 We provide helper functions to fetch icons from the theme folder, without it mattering if the icon is stored in the parent or child theme.
 
@@ -84,7 +86,8 @@ add_filter('acf_svg_icon_picker_custom_location', function () {
 
 ```php
 $fields->addField('my_icon', 'svg_icon_picker', [
-    'label' => 'My Icon',
+    'label'         => 'My Icon',
+    'return_format' => 'value', // or 'icon'
 ])
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ You can configure this field to output the icon name or the icon SVG markup. You
 We provide helper functions to fetch icons from the theme folder, without it mattering if the icon is stored in the parent or child theme.
 
 ```php
+use function SmithfieldStudio\AcfSvgIconPicker\get_svg_icon_uri;
+use function SmithfieldStudio\AcfSvgIconPicker\get_svg_icon_path;
+use function SmithfieldStudio\AcfSvgIconPicker\get_svg_icon;
+
 $my_icon_field = get_field('my_icon_field');
 
 // Get the icon URL

--- a/class-acf-field-svg-icon-picker.php
+++ b/class-acf-field-svg-icon-picker.php
@@ -161,7 +161,7 @@ class ACF_Field_Svg_Icon_Picker extends \acf_field
 					'close'    => esc_html__('close', 'acf-svg-icon-picker'),
 					'filter'   => esc_html__('Start typing to filter icons', 'acf-svg-icon-picker'),
 					// translators: %s: path_suffix
-					'no_icons' => sprintf(esc_html__('To add icons, add your svg files in the /%s folder in your theme.', 'acf-svg-icon-picker'), $this->path_suffix),
+					'no_icons' => sprintf(__('To add icons, add your svg files in the <code>/%s</code> folder in your theme.', 'acf-svg-icon-picker'), esc_attr($this->path_suffix)),
 				],
 			]
 		);

--- a/class-acf-field-svg-icon-picker.php
+++ b/class-acf-field-svg-icon-picker.php
@@ -168,8 +168,8 @@ class ACF_Field_Svg_Icon_Picker extends \acf_field
 				'type'         => 'radio',
 				'name'         => 'return_format',
 				'choices'      => [
-					'id'   => __('Value', 'acf-svg-icon-picker'),
-					'icon' => __('Icon', 'acf-svg-icon-picker'),
+					'value'   => __('Value', 'acf-svg-icon-picker'),
+					'icon'    => __('Icon', 'acf-svg-icon-picker'),
 				],
 				'layout'       => 'horizontal',
 			]

--- a/resources/scripts/input.js
+++ b/resources/scripts/input.js
@@ -13,12 +13,7 @@
 
       renderPopup();
 
-      // count amount of items in object
-      const count = Object.keys(acfSvgIconPicker.svgs).length;
-
-      if (count > 0) {
-        renderIconsList();
-      }
+      renderIconsList();
 
       setupFilter();
 

--- a/resources/styles/input.css
+++ b/resources/styles/input.css
@@ -15,6 +15,7 @@
   height: 50px;
   color: #aaa;
   font-weight: 300;
+  overflow: hidden;
   font-size: 20px;
   user-select: none;
 }
@@ -25,8 +26,13 @@
 
 .acf-svg-icon-picker__icon {
   padding: 15px;
+  background: 0;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
-  text-align: center;
 }
 
 .acf-svg-icon-picker__icon img {
@@ -100,7 +106,12 @@
 .acf-svg-icon-picker__popup-close {
   padding: 0;
   border: none;
+  cursor: pointer;
   background-color: transparent;
+}
+
+.acf-svg-icon-picker__popup-contents{
+  padding: 20px;
 }
 
 .acf-svg-icon-picker__popup ul {
@@ -108,7 +119,6 @@
   position: relative;
   grid-template-columns: repeat(var(--acfsip-columns, 4), calc(25% - var(--acfsip-spacing)));
   gap: var(--acfsip-spacing);
-  padding: 20px;
 }
 
 .acf-svg-icon-picker__popup ul li {

--- a/tests/TestPlugin.php
+++ b/tests/TestPlugin.php
@@ -43,7 +43,7 @@ class TestPlugin extends \WP_UnitTestCase
 		switch_theme('test-theme');
 
 		$plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-		$svgs = $plugin->svgs;
+		$svgs   = $plugin->svgs;
 		$this->assertNotEmpty($svgs);
 		$count = count($svgs);
 		$this->assertEquals(5, $count);
@@ -59,12 +59,11 @@ class TestPlugin extends \WP_UnitTestCase
 		switch_theme('test-child-theme');
 
 		$plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-		$svgs = $plugin->svgs;
+		$svgs   = $plugin->svgs;
 		$this->assertNotEmpty($svgs);
 		$count = count($svgs);
 		$this->assertEquals(6, $count);
 	}
-
 
 	/**
 	 * Test if the plugin collects the SVG files from the parent theme and the child theme and if the correct paths are used.
@@ -74,7 +73,7 @@ class TestPlugin extends \WP_UnitTestCase
 		switch_theme('test-child-theme');
 
 		$plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-		$svgs = $plugin->svgs;
+		$svgs   = $plugin->svgs;
 
 		// exists in both child and parent theme, thus child theme should be used
 		$discord = $svgs['discord'];
@@ -97,7 +96,7 @@ class TestPlugin extends \WP_UnitTestCase
 		});
 
 		$plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-		$svgs = $plugin->svgs;
+		$svgs   = $plugin->svgs;
 
 		$this->assertNotEmpty($svgs);
 		$count = count($svgs);
@@ -149,7 +148,7 @@ class TestPlugin extends \WP_UnitTestCase
 		});
 
 		$plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-		$svgs = $plugin->svgs;
+		$svgs   = $plugin->svgs;
 
 		$this->assertNotEmpty($svgs);
 		$count = count($svgs);
@@ -159,7 +158,6 @@ class TestPlugin extends \WP_UnitTestCase
 			return 'custom-icons/';
 		});
 	}
-
 
 	/**
 	 * Test if the _doing_it_wrong() function is called when the custom location filter is not used correctly.
@@ -173,7 +171,7 @@ class TestPlugin extends \WP_UnitTestCase
 		});
 
 		$plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-		$svgs = $plugin->svgs;
+		$svgs   = $plugin->svgs;
 		$this->setExpectedIncorrectUsage('check_priority_dir');
 	}
 
@@ -187,12 +185,12 @@ class TestPlugin extends \WP_UnitTestCase
 		add_filter('acf_svg_icon_picker_custom_location', function () {
 			return [
 				'path' => WP_CONTENT_DIR . '/random-location-icons/',
-				'url' =>  content_url() . '/random-location-icons/',
+				'url'  => content_url() . '/random-location-icons/',
 			];
 		});
 
 		$plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-		$svgs = $plugin->svgs;
+		$svgs   = $plugin->svgs;
 
 		$this->assertNotEmpty($svgs);
 		$count = count($svgs);
@@ -207,16 +205,93 @@ class TestPlugin extends \WP_UnitTestCase
 	 */
 	public function test_legacy_keys_still_find_icons()
 	{
-        switch_theme('test-theme');
+		switch_theme('test-theme');
 
-        $plugin = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
-        $icon_key = 'thunder-storm';
-        $legacy_icon_key = 'thunder storm';
+		$plugin          = new SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker();
+		$icon_key        = 'thunder-storm';
+		$legacy_icon_key = 'thunder storm';
 
-        $icon = $plugin->get_icon_data($icon_key);
-        $this->assertNotEmpty($icon);
+		$icon = $plugin->get_icon_data($icon_key);
+		$this->assertNotEmpty($icon);
 
-        $legacy_icon = $plugin->get_icon_data($legacy_icon_key);
-        $this->assertNotEmpty($legacy_icon);
+		$legacy_icon = $plugin->get_icon_data($legacy_icon_key);
+		$this->assertNotEmpty($legacy_icon);
+	}
+
+	public function testACFFieldSaveAndReturnValue()
+	{
+		// create a new field group
+		acf_add_local_field_group([
+			'key'      => 'group_svg_icon_picker',
+			'title'    => 'SVG Icon Picker',
+			'fields'   => [
+				[
+					'key'           => 'field_svg_icon_picker',
+					'label'         => 'SVG Icon Picker',
+					'name'          => 'svg_icon_picker',
+					'return_format' => 'value',
+					'type'          => 'svg_icon_picker',
+				],
+			],
+			'location' => [
+				[
+					[
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'post',
+					],
+				],
+			],
+		]);
+
+		// create a new post
+		$post_id = $this->factory->post->create();
+
+		// set the field value
+		update_field('svg_icon_picker', 'bell', $post_id);
+
+		// get the field value
+		$field_value = get_field('svg_icon_picker', $post_id);
+		$this->assertEquals('bell', $field_value);
+	}
+
+	public function testACFFieldSaveAndReturnSVG()
+	{
+		switch_theme('test-theme');
+		// create a new field group
+		acf_add_local_field_group([
+			'key'      => 'group_svg_icon_picker_2',
+			'title'    => 'SVG Icon Picker',
+			'fields'   => [
+				[
+					'key'           => 'field_svg_icon_picker_svg_test',
+					'label'         => 'SVG Icon Picker',
+					'name'          => 'svg_icon_picker',
+					'return_format' => 'icon',
+					'type'          => 'svg_icon_picker',
+				],
+			],
+			'location' => [
+				[
+					[
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'post',
+					],
+				],
+			],
+		]);
+
+		// create a new post
+		$post_id = $this->factory->post->create();
+
+		// set the field value
+		update_field('field_svg_icon_picker_svg_test', 'discord', $post_id);
+
+		// get file in /assets/themes/test-theme/icons/discord.svg
+		$discord_svg = file_get_contents(WP_CONTENT_DIR . '/themes/test-theme/icons/discord.svg');
+
+		$field_value = get_field('field_svg_icon_picker_svg_test', $post_id);
+		$this->assertEquals($discord_svg, $field_value);
 	}
 }


### PR DESCRIPTION
Related:

- #30

## Issue
- There is currently no easy way to get an icon directly.
- The rendered state of the plugin and field could use some additional love

## Solution
Provide an output option that you can choose when creating this field to output the SVG directly when found.

For the styling issues, I added some additional styling as well. Would have been better to create a seperate PR, but hey, here we are 👯 

## Impact
Easier to interact with the plugin but some more things to test for.


## Usage Changes
no

## Considerations
no

## Testing
We need to add some tests for checking the output of the field as well.
