### PR TITLE
Change action hook for field type registration

### DIFF
--- a/acf-svg-icon-picker.php
+++ b/acf-svg-icon-picker.php
@@ -43,7 +43,7 @@ function include_field_types(): void
 	acf_register_field_type('SmithfieldStudio\AcfSvgIconPicker\ACF_Field_Svg_Icon_Picker');
 }
 
-add_action('init', __NAMESPACE__ . '\\include_field_types');
+add_action('acf/include_field_types', __NAMESPACE__ . '\\include_field_types');
 
 
 /**


### PR DESCRIPTION
ACF provides a hook for this, so the plugin does not require loading in every instance, which causes lag in some sites - can you please update it?

<img width="1751" height="551" alt="ACFIcon____New_Relic" src="https://github.com/user-attachments/assets/9f198aba-9cc4-459d-ac8c-eb5ba41be22a" />
