### PR TITLE
chore: increase z-index for ACF block v3 compatibility

### DIFF
--- a/resources/styles/input.css
+++ b/resources/styles/input.css
@@ -72,7 +72,7 @@
   display: grid;
   position: fixed;
   place-items: center;
-  z-index: 99999;
+  z-index: 999999999;
   inset: 0;
   background-color: rgba(0, 0, 0, 0.8);
 }


### PR DESCRIPTION
## Issue
When using the ACF block version 3, the icon selector pop-up is behind the extended ACF sidebar. So it is not usable. 


## Solution
Increase the set index of the pop-up to a greater number 


## Impact
No impact 


## Usage Changes
None

## Considerations
--


## Testing
visual test made; works.
